### PR TITLE
Revert "Use patterrn match in bors.toml"

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,7 @@
 status = [
     'rustfmt',
-    'test %',
+    'test (macOS-latest)',
+    'test (windows-2019)',
+    'test (ubuntu-latest)'
 ]
 delete_merged_branches = true


### PR DESCRIPTION
This reverts commit 88d4e2854b54be3dc1badfffefa9de3262e55a0e.